### PR TITLE
Use wrapping mul in the pseudorandom generation function

### DIFF
--- a/src/functional.rs
+++ b/src/functional.rs
@@ -36,7 +36,7 @@ pub fn random_u32(mut state: u64) -> u32 {
     state ^= state << 25;
     state ^= state >> 27;
 
-    ((state * 0x2545F4914F6CDD1Du64) >> 32) as u32
+    ((state.wrapping_mul(0x2545F4914F6CDD1Du64)) >> 32) as u32
 }
 
 pub fn random_f32(state: u64) -> f32 { 


### PR DESCRIPTION
In Rust the behavior of multiplication overflow depends of the compilation mode:
- it wraps by default in release mode
- but panics in debug

This change makes it possible to run the code in debug mode without triggering a panic.