### PR TITLE
Remove all unsafe code related to memory-management in `transformer.rs`

### DIFF
--- a/src/bin/chat.rs
+++ b/src/bin/chat.rs
@@ -1,16 +1,16 @@
+use lmrs::sampler::Sampler;
+use lmrs::tokenizer::Tokenizer;
 use lmrs::transformer::ModelType;
 use lmrs::transformer::Transformer;
-use lmrs::tokenizer::Tokenizer;
-use lmrs::sampler::Sampler;
 
+use chrono::Local;
+use clap::Parser;
+use memmap2::Mmap;
 use std::fs;
+use std::fs::File;
 use std::io;
 use std::io::Write;
-use std::fs::File;
-use clap::Parser;
-use std::time::{SystemTime, UNIX_EPOCH, Instant};
-use memmap2::Mmap;
-use chrono::Local;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 #[derive(Parser)]
 struct Args {
@@ -43,24 +43,32 @@ fn main() {
     let model_path: &str = args.model.as_str();
     let tokenizer_path: &str = args.tokenizer.as_str();
 
-    assert!(fs::metadata(tokenizer_path).is_ok(), "Tokenizer file not found: {}", tokenizer_path);
-    assert!(fs::metadata(model_path).is_ok(), "Model file not found: {}", model_path);
+    assert!(
+        fs::metadata(tokenizer_path).is_ok(),
+        "Tokenizer file not found: {}",
+        tokenizer_path
+    );
+    assert!(
+        fs::metadata(model_path).is_ok(),
+        "Model file not found: {}",
+        model_path
+    );
 
     let mut tokenizer = Tokenizer::new(args.tokenizer.as_str());
 
     let file = File::open(model_path).expect("Error opening model file");
-    let data = unsafe { Mmap::map(&file).expect("MMap failed")  };
+    let data = unsafe { Mmap::map(&file).expect("MMap failed") };
 
     let mut model = Transformer::new(&data);
 
     let seed: u64 = match args.seed {
-        Some(seed_value) => {
-            seed_value
-        }
+        Some(seed_value) => seed_value,
         None => {
             let start = SystemTime::now();
-            let since_epoch = start.duration_since(UNIX_EPOCH).expect("Error getting time since epoch");
-            
+            let since_epoch = start
+                .duration_since(UNIX_EPOCH)
+                .expect("Error getting time since epoch");
+
             since_epoch.as_millis() as u64
         }
     };
@@ -81,32 +89,49 @@ fn main() {
     let mut user_prompt: String;
 
     loop {
-        if user_turn { 
+        if user_turn {
             user_prompt = String::from("");
 
             print!("You: ");
             io::stdout().flush().unwrap();
 
-            io::stdin().read_line(&mut user_prompt).expect("Failed to read line");
-            
+            io::stdin()
+                .read_line(&mut user_prompt)
+                .expect("Failed to read line");
+
             // System prompt
             if model.args.model_type == ModelType::LLAMA && pos == 0 {
                 // First part of chat template with initial tags and cut off date
-                prompt_tokens.extend([128000, 128006, 9125, 128007, 271, 38766, 1303, 33025, 2696, 25, 6790, 220, 2366, 18, 198, 15724, 2696, 25, 220]);
-                
+                prompt_tokens.extend([
+                    128000, 128006, 9125, 128007, 271, 38766, 1303, 33025, 2696, 25, 6790, 220,
+                    2366, 18, 198, 15724, 2696, 25, 220,
+                ]);
+
                 let today = Local::now().date_naive();
                 let formatted_date = today.format("%d %b %Y").to_string();
-                prompt_tokens.extend(tokenizer.encode(&formatted_date, false, false, false, model.args.model_type));
+                prompt_tokens.extend(tokenizer.encode(
+                    &formatted_date,
+                    false,
+                    false,
+                    false,
+                    model.args.model_type,
+                ));
 
                 prompt_tokens.extend([271, 128009])
             }
 
-            prompt_tokens.extend(tokenizer.encode(user_prompt.trim(), false, false, true, model.args.model_type));
+            prompt_tokens.extend(tokenizer.encode(
+                user_prompt.trim(),
+                false,
+                false,
+                true,
+                model.args.model_type,
+            ));
             num_prompt_tokens = prompt_tokens.len();
 
-            user_turn = false; 
+            user_turn = false;
             user_idx = 0;
-            
+
             println!("Assistant:");
         }
 
@@ -116,35 +141,38 @@ fn main() {
         } else {
             token = next;
         }
-        
-        if token == tokenizer.eos && user_idx >= num_prompt_tokens { 
-            user_turn = true; 
+
+        if token == tokenizer.eos && user_idx >= num_prompt_tokens {
+            user_turn = true;
             println!();
             prompt_tokens = Vec::new();
-            
+
             if args.show_metrics {
-                let toks = total_tokens/(total_duration/1000.0);
-                
+                let toks = total_tokens / (total_duration / 1000.0);
+
                 println!("Speed: {:.2} tok/s", toks);
 
                 total_duration = 0.0;
                 total_tokens = 0.0;
-            } 
+            }
 
             continue;
         }
-        
+
         let processing_start = Instant::now();
 
         let logits: &mut [f32] = model.forward(token, pos);
         next = sampler.sample(logits);
         pos += 1;
 
-        if user_idx >= num_prompt_tokens && next != tokenizer.eos && !(model.args.model_type == ModelType::GEMMA && next == 107) {
+        if user_idx >= num_prompt_tokens
+            && next != tokenizer.eos
+            && !(model.args.model_type == ModelType::GEMMA && next == 107)
+        {
             let piece = tokenizer.decode(next);
             print!("{}", piece);
             io::stdout().flush().unwrap();
-        }   
+        }
 
         let duration = processing_start.elapsed();
         total_duration += duration.as_millis() as f32;

--- a/src/functional.rs
+++ b/src/functional.rs
@@ -2,7 +2,25 @@ use crate::quantization::{MutableQuantizedTensor, QuantizedTensor};
 
 use rayon::prelude::*;
 use std::convert::TryInto;
+use std::ops::Deref;
 use wide::{f32x8, i32x8};
+
+/// Allocs to use either a `Vec` or a slice in the same place
+pub enum SliceOrVec<'a, T> {
+    Slice(&'a [T]),
+    Vec(Vec<T>),
+}
+
+impl<'a, T> Deref for SliceOrVec<'a, T> {
+    type Target = [T];
+
+    fn deref(&self) -> &[T] {
+        match self {
+            &Self::Slice(slice) => slice,
+            &Self::Vec(ref vec) => &vec[..],
+        }
+    }
+}
 
 // Some helper functions
 

--- a/src/functional.rs
+++ b/src/functional.rs
@@ -1,11 +1,10 @@
+use crate::quantization::{MutableQuantizedTensor, QuantizedTensor};
 
-use crate::quantization::{QuantizedTensor, MutableQuantizedTensor};
-
-use std::{convert::TryInto};
 use rayon::prelude::*;
+use std::convert::TryInto;
 use wide::{f32x8, i32x8};
 
-// Some helper functions 
+// Some helper functions
 
 pub fn slice_to_u32(slice: &[u8]) -> u32 {
     assert!(slice.len() == 4, "Slice must be exactly 4 bytes long");
@@ -39,21 +38,28 @@ pub fn random_u32(mut state: u64) -> u32 {
     ((state * 0x2545F4914F6CDD1Du64) >> 32) as u32
 }
 
-pub fn random_f32(state: u64) -> f32 { 
+pub fn random_f32(state: u64) -> f32 {
     (random_u32(state) >> 8) as f32 / 16777216.0f32
 }
 
 // Functions used in NNs
 
-pub fn rmsnorm(o: &mut [f32], x: &[f32], weight: &[f32], size: usize, eps: f32, add_unit_offset: bool) {
-    let n_simd = size/8;
+pub fn rmsnorm(
+    o: &mut [f32],
+    x: &[f32],
+    weight: &[f32],
+    size: usize,
+    eps: f32,
+    add_unit_offset: bool,
+) {
+    let n_simd = size / 8;
 
     let mut ss_sim = f32x8::ZERO;
 
     for j in 0..n_simd {
-        let x_vec = f32x8::from(&x[j*8..j*8+8]); 
+        let x_vec = f32x8::from(&x[j * 8..j * 8 + 8]);
         ss_sim += x_vec * x_vec;
-    } 
+    }
 
     let mut ss = ss_sim.reduce_add();
 
@@ -62,9 +68,9 @@ pub fn rmsnorm(o: &mut [f32], x: &[f32], weight: &[f32], size: usize, eps: f32, 
     ss = 1.0 / ss.sqrt();
 
     for j in 0..n_simd {
-        let x_vec = f32x8::from(&x[j*8..j*8+8]);
-        let w_vec = f32x8::from(&weight[j*8..j*8+8]);
-        
+        let x_vec = f32x8::from(&x[j * 8..j * 8 + 8]);
+        let w_vec = f32x8::from(&weight[j * 8..j * 8 + 8]);
+
         let r = if add_unit_offset {
             ((1.0 + w_vec) * (ss * x_vec)).to_array()
         } else {
@@ -72,12 +78,12 @@ pub fn rmsnorm(o: &mut [f32], x: &[f32], weight: &[f32], size: usize, eps: f32, 
         };
 
         for k in 0..8 {
-            o[(j*8) + k] = r[k];
-        } 
-    } 
+            o[(j * 8) + k] = r[k];
+        }
+    }
 }
 
-pub fn softmax(x: &mut [f32]){
+pub fn softmax(x: &mut [f32]) {
     let mut sum: f32 = 0.0;
     let mut max_val: f32 = x[0];
 
@@ -91,10 +97,10 @@ pub fn softmax(x: &mut [f32]){
         *i = (*i - max_val).exp();
         sum += *i;
     }
-    
+
     for i in x.iter_mut() {
         *i /= sum;
-    } 
+    }
 }
 
 pub fn matmul(xout: &mut [f32], x: &[f32], w: &[f32]) {
@@ -106,8 +112,8 @@ pub fn matmul(xout: &mut [f32], x: &[f32], w: &[f32]) {
         let w_slice = &w[i * n..i * n + n];
 
         for j in 0..n_simd {
-            let x_vec = f32x8::from(&x[j*8..j*8+8]);
-            let w_vec = f32x8::from(&w_slice[j*8..j*8+8]);
+            let x_vec = f32x8::from(&x[j * 8..j * 8 + 8]);
+            let w_vec = f32x8::from(&w_slice[j * 8..j * 8 + 8]);
             sum += w_vec * x_vec;
         }
 
@@ -115,55 +121,73 @@ pub fn matmul(xout: &mut [f32], x: &[f32], w: &[f32]) {
     });
 }
 
-pub fn matmul_q8(xout: &mut [f32], x: &MutableQuantizedTensor, w: &QuantizedTensor, n: usize, gs: usize) {
+pub fn matmul_q8(
+    xout: &mut [f32],
+    x: &MutableQuantizedTensor,
+    w: &QuantizedTensor,
+    n: usize,
+    gs: usize,
+) {
     let n_simd = gs / 8;
-    
+
     xout.par_iter_mut().enumerate().for_each(|(i, xout_elem)| {
         let ni: usize = i * n;
 
-        *xout_elem = (0..=(n - gs)).step_by(gs).map(|j| {
-            let mut ival = i32x8::ZERO;
+        *xout_elem = (0..=(n - gs))
+            .step_by(gs)
+            .map(|j| {
+                let mut ival = i32x8::ZERO;
 
-            for k in 0..n_simd {
-                let x_vec = i32x8::from(&x.q[j+k*8..j+k*8+8]);
-                let w_vec = i32x8::from(&w.q[ni+j+k*8..ni+j+k*8+8]);
+                for k in 0..n_simd {
+                    let x_vec = i32x8::from(&x.q[j + k * 8..j + k * 8 + 8]);
+                    let w_vec = i32x8::from(&w.q[ni + j + k * 8..ni + j + k * 8 + 8]);
 
-                ival += x_vec * w_vec;
-            }
+                    ival += x_vec * w_vec;
+                }
 
-            (ival.reduce_add() as f32) * w.s[(ni + j) / gs] * x.s[j / gs]
-        }).sum();
+                (ival.reduce_add() as f32) * w.s[(ni + j) / gs] * x.s[j / gs]
+            })
+            .sum();
     });
 }
 
-pub fn matmul_q4(xout: &mut [f32], x: &MutableQuantizedTensor, w: &QuantizedTensor, n: usize, gs: usize) {
+pub fn matmul_q4(
+    xout: &mut [f32],
+    x: &MutableQuantizedTensor,
+    w: &QuantizedTensor,
+    n: usize,
+    gs: usize,
+) {
     let group_size = gs / 2;
     let n_simd = group_size / 8;
 
     let mask_a = i32x8::new([0x0F; 8]);
     let mask_b = i32x8::new([0xF0; 8]);
-    
+
     xout.par_iter_mut().enumerate().for_each(|(i, xout_elem)| {
         let ni: usize = i * n / 2;
 
-        *xout_elem = (0..=(n/2 - group_size)).step_by(group_size).map(|j| {
-            let mut ival = i32x8::ZERO;
+        *xout_elem = (0..=(n / 2 - group_size))
+            .step_by(group_size)
+            .map(|j| {
+                let mut ival = i32x8::ZERO;
 
-            for k in 0..n_simd {
-                let x_vec = i32x8::from(&x.q[j+k*8..j+k*8+8]);
-                let w_vec = i32x8::from(&w.q[ni+j+k*8..ni+j+k*8+8]);
+                for k in 0..n_simd {
+                    let x_vec = i32x8::from(&x.q[j + k * 8..j + k * 8 + 8]);
+                    let w_vec = i32x8::from(&w.q[ni + j + k * 8..ni + j + k * 8 + 8]);
 
-                let x_a = (x_vec & mask_a) - 8;
-                let w_a = (w_vec & mask_a) - 8;
-                
-                let x_b = (mask_a & ((x_vec & mask_b) >> 4)) - 8;
-                let w_b = (mask_a & ((w_vec & mask_b) >> 4)) - 8;
+                    let x_a = (x_vec & mask_a) - 8;
+                    let w_a = (w_vec & mask_a) - 8;
 
-                ival += x_a * w_a;
-                ival += x_b * w_b;
-            }
+                    let x_b = (mask_a & ((x_vec & mask_b) >> 4)) - 8;
+                    let w_b = (mask_a & ((w_vec & mask_b) >> 4)) - 8;
 
-            (ival.reduce_add() as f32) * w.s[(ni + j) / group_size] * x.s[j / group_size]
-        }).sum();
+                    ival += x_a * w_a;
+                    ival += x_b * w_b;
+                }
+
+                (ival.reduce_add() as f32) * w.s[(ni + j) / group_size] * x.s[j / group_size]
+            })
+            .sum();
     });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-pub mod tokenizer;
 pub mod functional;
-pub mod transformer;
-pub mod sampler;
 pub mod quantization;
+pub mod sampler;
+pub mod tokenizer;
+pub mod transformer;

--- a/src/quantization.rs
+++ b/src/quantization.rs
@@ -9,9 +9,9 @@ pub struct QuantizedTensor<'a> {
     pub q: &'a [i8],
     pub s: &'a [f32],
 }
-pub struct MutableQuantizedTensor<'a> {
-    pub q: &'a mut [i8],
-    pub s: &'a mut [f32],
+pub struct MutableQuantizedTensor {
+    pub q: Vec<i8>,
+    pub s: Vec<f32>,
 }
 
 fn unpack(value: i8) -> (i8, i8) {

--- a/src/quantization.rs
+++ b/src/quantization.rs
@@ -5,11 +5,11 @@ pub enum QuantType {
     Q4_0,
 }
 
-pub struct QuantizedTensor<'a>{
+pub struct QuantizedTensor<'a> {
     pub q: &'a [i8],
     pub s: &'a [f32],
 }
-pub struct MutableQuantizedTensor<'a>{
+pub struct MutableQuantizedTensor<'a> {
     pub q: &'a mut [i8],
     pub s: &'a mut [f32],
 }
@@ -24,24 +24,24 @@ fn unpack(value: i8) -> (i8, i8) {
 
 pub fn dequantize(qx: &QuantizedTensor, x: &mut [f32], n: usize, gs: u32, q_type: QuantType) {
     match q_type {
-        QuantType::Q8_0 => { 
+        QuantType::Q8_0 => {
             for (i, value) in x.iter_mut().enumerate().take(n) {
                 *value = qx.q[i] as f32 * qx.s[(i as u32 / gs) as usize];
             }
-        },
-        QuantType::Q4_0 => { 
-            for i in 0..(n/2) {
+        }
+        QuantType::Q4_0 => {
+            for i in 0..(n / 2) {
                 let (a, b) = unpack(qx.q[i]);
-                let scale = qx.s[((i*2) as u32 / gs) as usize];
-                x[i*2] = a as f32 * scale;
-                x[i*2+1] = b as f32 * scale;
+                let scale = qx.s[((i * 2) as u32 / gs) as usize];
+                x[i * 2] = a as f32 * scale;
+                x[i * 2 + 1] = b as f32 * scale;
             }
-        },
+        }
         _ => (),
-    }  
+    }
 }
 
-pub fn quantize(qx: &mut MutableQuantizedTensor, x: & [f32], n: usize, gs: u32) {
+pub fn quantize(qx: &mut MutableQuantizedTensor, x: &[f32], n: usize, gs: u32) {
     let num_groups: u32 = n as u32 / gs;
     let q_max: f32 = 127.0f32;
 
@@ -55,7 +55,7 @@ pub fn quantize(qx: &mut MutableQuantizedTensor, x: & [f32], n: usize, gs: u32) 
         }
 
         let scale = wmax / q_max;
-        
+
         qx.s[group as usize] = scale;
 
         for i in 0..gs {
@@ -66,7 +66,7 @@ pub fn quantize(qx: &mut MutableQuantizedTensor, x: & [f32], n: usize, gs: u32) 
     }
 }
 
-pub fn quantize_q4(qx: &mut MutableQuantizedTensor, x: & [f32], n: usize, gs: u32) {
+pub fn quantize_q4(qx: &mut MutableQuantizedTensor, x: &[f32], n: usize, gs: u32) {
     let num_groups: u32 = n as u32 / gs;
     let q_max: f32 = -8.0f32;
 
@@ -80,15 +80,15 @@ pub fn quantize_q4(qx: &mut MutableQuantizedTensor, x: & [f32], n: usize, gs: u3
         }
 
         let scale = wmax / q_max;
-        
+
         qx.s[group as usize] = scale;
 
-        for i in 0..(gs/2) {
-            let quant_value_a = x[(group * gs + i*2) as usize] / scale;
-            let quant_value_b = x[(group * gs + i*2 + 1) as usize] / scale;
+        for i in 0..(gs / 2) {
+            let quant_value_a = x[(group * gs + i * 2) as usize] / scale;
+            let quant_value_b = x[(group * gs + i * 2 + 1) as usize] / scale;
             let quantized_a: i8 = ((quant_value_a + 8.0).round() as u8).clamp(0, 15) as i8;
             let quantized_b: i8 = ((quant_value_b + 8.0).round() as u8).clamp(0, 15) as i8;
-        
+
             qx.q[(group * gs / 2 + i) as usize] = quantized_a | (quantized_b << 4);
         }
     }

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -1,5 +1,5 @@
-use crate::functional::softmax;
 use crate::functional::random_f32;
+use crate::functional::softmax;
 
 #[derive(Debug, Copy, Clone)]
 struct ProbIndex {
@@ -19,13 +19,19 @@ impl Sampler {
     pub fn new(vocab_size: u32, temperature: f32, top_p: f32, seed: u64) -> Sampler {
         Sampler {
             vocab_size,
-            probindex: vec![ProbIndex { prob: 0.0, index: 0 }; vocab_size as usize],
+            probindex: vec![
+                ProbIndex {
+                    prob: 0.0,
+                    index: 0
+                };
+                vocab_size as usize
+            ],
             temperature,
             top_p,
-            seed
+            seed,
         }
     }
-    
+
     fn sample_argmax(probabilities: &[f32]) -> u32 {
         let mut max_i: u32 = 0;
         let mut max_p = probabilities[0];
@@ -68,7 +74,7 @@ impl Sampler {
         let n = probabilities.len();
         let mut n0 = 0;
 
-        let  cutoff: f32 = (1.0f32 - top_p) / (n - 1) as f32;
+        let cutoff: f32 = (1.0f32 - top_p) / (n - 1) as f32;
 
         for (i, p) in probabilities.iter().enumerate() {
             if *p >= cutoff {
@@ -77,7 +83,7 @@ impl Sampler {
                 n0 += 1;
             }
         }
-        
+
         self.probindex.sort_by(Sampler::compare);
 
         let mut cumulative_prob: f32 = 0.0;
@@ -95,7 +101,7 @@ impl Sampler {
         let r = rand * cumulative_prob;
         let mut cdf: f32 = 0.0;
 
-        for i in 0..last_idx+1 {
+        for i in 0..last_idx + 1 {
             cdf += self.probindex[i].prob;
             if r < cdf {
                 return self.probindex[i].index;
@@ -105,14 +111,15 @@ impl Sampler {
         self.probindex[last_idx].index
     }
 
-
     pub fn sample(&mut self, logits: &mut [f32]) -> u32 {
         let next: u32;
-        
+
         if self.temperature == 0.0f32 {
             next = Sampler::sample_argmax(logits);
         } else {
-            for q in 0..self.vocab_size { logits[q as usize] /= self.temperature; }
+            for q in 0..self.vocab_size {
+                logits[q as usize] /= self.temperature;
+            }
 
             softmax(logits);
 


### PR DESCRIPTION
This PR removes all the memory-management related unsafe code in `transformer.rs`, leveraging RAII instead of using `Box::leak`+ manual deallocation and replacing `MaybeUninit` with `Option` for the weights that aren't initialized.