### PR TITLE
remove simd, improves perf on arm64 cpu by x2

### DIFF
--- a/src/functional.rs
+++ b/src/functional.rs
@@ -171,8 +171,6 @@ pub fn matmul(xout: &mut [f32], x: &[f32], w: &[f32], n: usize, o: usize) {
 }
 
 pub fn matmul_q8(xout: &mut [f32], x: &MutableQuantizedTensor, w: &QuantizedTensor, n: usize, o: usize, gs: usize) {
-    let n_simd = gs / 8;
-    
     xout.par_chunks_exact_mut(o).enumerate().for_each(|(j, elem)| {
         let xi = j*n;
 
@@ -186,28 +184,23 @@ pub fn matmul_q8(xout: &mut [f32], x: &MutableQuantizedTensor, w: &QuantizedTens
             xout_elem.iter_mut().for_each(|m| *m = 0.0);
 
             for j in (0..=(n - gs)).step_by(gs) {
-                let mut ival0 = i32x8::ZERO;
-                let mut ival1 = i32x8::ZERO;
-                let mut ival2 = i32x8::ZERO;
-                let mut ival3 = i32x8::ZERO;
+                let mut ival0 = 0;
+                let mut ival1 = 0;
+                let mut ival2 = 0;
+                let mut ival3 = 0;
 
-                for k in 0..n_simd {
-                    let x_vec = i32x8::from(&x.q[xi+j+k*8..xi+j+k*8+8]);
-                    let w_vec0 = i32x8::from(&w.q[ni0+j+k*8..ni0+j+k*8+8]);
-                    let w_vec1 = i32x8::from(&w.q[ni1+j+k*8..ni1+j+k*8+8]);
-                    let w_vec2 = i32x8::from(&w.q[ni2+j+k*8..ni2+j+k*8+8]);
-                    let w_vec3 = i32x8::from(&w.q[ni3+j+k*8..ni3+j+k*8+8]);
-
-                    ival0 += x_vec * w_vec0;
-                    ival1 += x_vec * w_vec1;
-                    ival2 += x_vec * w_vec2;
-                    ival3 += x_vec * w_vec3;
+                for k in 0..gs {
+                    let x_val = x.q[xi + j + k] as i32;
+                    ival0 += x_val * w.q[ni0 + j + k] as i32;
+                    ival1 += x_val * w.q[ni1 + j + k] as i32;
+                    ival2 += x_val * w.q[ni2 + j + k] as i32;
+                    ival3 += x_val * w.q[ni3 + j + k] as i32;
                 }
 
-                xout_elem[0] += (ival0.reduce_add() as f32) * w.s[(ni0 + j) / gs] * x.s[(xi + j) / gs];
-                xout_elem[1] += (ival1.reduce_add() as f32) * w.s[(ni1 + j) / gs] * x.s[(xi + j) / gs];
-                xout_elem[2] += (ival2.reduce_add() as f32) * w.s[(ni2 + j) / gs] * x.s[(xi + j) / gs];
-                xout_elem[3] += (ival3.reduce_add() as f32) * w.s[(ni3 + j) / gs] * x.s[(xi + j) / gs];
+                xout_elem[0] += (ival0 as f32) * w.s[(ni0 + j) / gs] * x.s[(xi + j) / gs];
+                xout_elem[1] += (ival1 as f32) * w.s[(ni1 + j) / gs] * x.s[(xi + j) / gs];
+                xout_elem[2] += (ival2 as f32) * w.s[(ni2 + j) / gs] * x.s[(xi + j) / gs];
+                xout_elem[3] += (ival3 as f32) * w.s[(ni3 + j) / gs] * x.s[(xi + j) / gs];
             }
         });
     });

--- a/src/functional.rs
+++ b/src/functional.rs
@@ -215,10 +215,9 @@ pub fn matmul_q8(xout: &mut [f32], x: &MutableQuantizedTensor, w: &QuantizedTens
 
 pub fn matmul_q4(xout: &mut [f32], x: &MutableQuantizedTensor, w: &QuantizedTensor, n: usize, o: usize, gs: usize) {
     let group_size = gs / 2;
-    let n_simd = group_size / 8;
 
-    let mask_a = i32x8::new([0x0F; 8]);
-    let mask_b = i32x8::new([0xF0; 8]);
+    let mask_a: i16 = 0x0F;
+    let mask_b: i16 = 0xF0;
     
     xout.par_chunks_exact_mut(o).enumerate().for_each(|(j, elem)| {
         let xi = j*n;
@@ -227,23 +226,22 @@ pub fn matmul_q4(xout: &mut [f32], x: &MutableQuantizedTensor, w: &QuantizedTens
             let ni: usize = i * n / 2;
 
             *xout_elem = (0..=(n/2 - group_size)).step_by(group_size).map(|j| {
-                let mut ival = i32x8::ZERO;
+                let mut ival = 0;
 
-                for k in 0..n_simd {
-                    let x_vec = i32x8::from(&x.q[xi+j+k*8..xi+j+k*8+8]);
-                    let w_vec = i32x8::from(&w.q[ni+j+k*8..ni+j+k*8+8]);
+                let x_vec = &x.q[xi+j..xi+j+group_size];
+                let w_vec = &w.q[ni+j..ni+j+group_size];
 
-                    let x_a = (x_vec & mask_a) - 8;
-                    let w_a = (w_vec & mask_a) - 8;
-                    
-                    let x_b = (mask_a & ((x_vec & mask_b) >> 4)) - 8;
-                    let w_b = (mask_a & ((w_vec & mask_b) >> 4)) - 8;
+                for l in 0..group_size {
+                    let x_a = (x_vec[l] as i16 & mask_a) - 8;
+                    let w_a = (w_vec[l] as i16 & mask_a) - 8;
 
-                    ival += x_a * w_a;
-                    ival += x_b * w_b;
+                    let x_b = ((x_vec[l] as i16 & mask_b) >> 4) - 8;
+                    let w_b = ((w_vec[l] as i16 & mask_b) >> 4) - 8;
+
+                    ival += x_a * w_a + x_b * w_b;
                 }
 
-                (ival.reduce_add() as f32) * w.s[(ni + j) / group_size] * x.s[(xi + j) / group_size] 
+                (ival as f32) * w.s[(ni + j) / group_size] * x.s[(xi + j) / group_size] 
             }).sum();
         });
     });


### PR DESCRIPTION
On Arm64 cpu, removing the SIMD in matmul allows the compiler to optimise it for arm64. The performance in my experiments goes from around ~2 t/s to ~4.5 t/s.

 I'm not sure if this has any performance implications for running on x86, as I don't have one to test on. If it does make it slower, than I'm happy to put this version behind a target flag for arm64 e.g. https://docs.rs/core_arch/latest/core_arch/#static-cpu-feature-detection

Before
```
❯ cargo build --release --bin chat && ./target/release/chat --model model/llama3.2-3b-it-q40.lmrs --tokenizer model/tokenizer.bin --show-metrics --temperature 0
   Compiling lmrs v0.1.0 (../lm.rs)
    Finished `release` profile [optimized] target(s) in 22.27s

    L      M     M  RRRR    ssss
    L      MM   MM  R   R  s
    L      M M M M  RRRR    sss
    L      M  M  M  R  R       s
    LLLL   M     M  R   R  sssss
    
LMRS version: 4
Model type: LLAMA

Using Q4_0 quantization.
Loading weights...
Done.

You: hello there
Assistant:
Hello! It's nice to meet you. Is there something I can help you with, or would you like to chat for a bit?
Speed: 1.98 tok/s
You: 
```

After
```
❯ cargo build --release --bin chat && ./target/release/chat --model model/llama3.2-3b-it-q40.lmrs --tokenizer model/tokenizer.bin --show-metrics --temperature 0
   Compiling lmrs v0.1.0 (../lm.rs)
    Finished `release` profile [optimized] target(s) in 21.72s

    L      M     M  RRRR    ssss
    L      MM   MM  R   R  s
    L      M M M M  RRRR    sss
    L      M  M  M  R  R       s
    LLLL   M     M  R   R  sssss
    
LMRS version: 4
Model type: LLAMA

Using Q4_0 quantization.
Loading weights...
Done.

You: hello there
Assistant:
Hello! It's nice to meet you. Is there something I can help you with, or would you like to chat for a bit?
Speed: 4.67 tok/s
You:
```